### PR TITLE
Create S3 buckets with short lifetime

### DIFF
--- a/deployer/main.py
+++ b/deployer/main.py
@@ -42,8 +42,15 @@ def cli(ctx, debug):
     default=False,
     help="Ignores checking if files exist already",
 )
+@click.option(
+    "-l",
+    "--lifecycle-days",
+    required=False,
+    type=int,
+    help="If specified, the number of days until uploaded objects are deleted",
+)
 @click.argument("directory", type=click.Path())
-def upload(ctx, directory, name, refresh):
+def upload(ctx, directory, name, refresh, lifecycle_days):
     p = Path(directory)
     if not p.exists():
         error(f"{directory} does not exist")
@@ -51,6 +58,8 @@ def upload(ctx, directory, name, refresh):
 
     ctx.obj["name"] = name
     ctx.obj["refresh"] = refresh
+    ctx.obj["lifecycle_days"] = lifecycle_days
+    # print(ctx.obj)
     upload_site(directory, ctx.obj)
 
 


### PR DESCRIPTION
Fixes #2

At least I *think* it works. I tested it like this:
```
stumptown-deployer upload ~/stumptown-renderer/client/build/ -l 3
```

If this works, we'll need something like 
```
stumptown-deployer upload
```
which loops over all S3 buckets that match some sort of prefix and has exactly 0 things in it. 